### PR TITLE
changed Sigma 24mm f/1.4 and Sigma 105mm f/2.8 EX DG OS HSM Macro

### DIFF
--- a/data/db/slr-sigma.xml
+++ b/data/db/slr-sigma.xml
@@ -2137,7 +2137,8 @@
 
     <lens>
         <maker>Sigma</maker>
-        <model>Sigma 24mm f/1.4 DG HSM [A]</model>
+        <model>Sigma 24mm f/1.4 DG HSM | [A] Art 015</model>
+        <model lang="en">Sigma 24mm f/1.4 DG HSM | A</model>
         <mount>Nikon F AF</mount>
         <mount>Sigma SA</mount>
         <mount>Canon EF</mount>
@@ -2921,6 +2922,7 @@
         <maker>Sigma</maker>
         <model>Sigma 105mm f/2.8 EX DG OS HSM Macro</model>
         <mount>Nikon F AF</mount>
+        <mount>Canon EF</mount>
         <cropfactor>1</cropfactor>
         <calibration>
             <!-- Taken with Nikon D610 -->


### PR DESCRIPTION
changed Sigma 24mm f/1.4 for Canon EOS 6D, added Canon EF for Sigma 105mm f/2.8 EX DG OS HSM Macro cropfactor 1

this solution worked for the Sigma 24mm 1.4 -> https://github.com/lensfun/lensfun/issues/1946

I also added Canon EF mount to cropfactor 1 for Sigma 105mm 2.8 as i own this lens and it also didn't get recognized if used with EOS 6D